### PR TITLE
chore: add sbom generation and upload workflow

### DIFF
--- a/.github/workflows/generate-maven-sbom.yaml
+++ b/.github/workflows/generate-maven-sbom.yaml
@@ -1,0 +1,72 @@
+name: Generate Maven SBOM
+
+on:
+  push:
+    tags:
+      - "v**" # Triggers when someone pushes a tag that starts with 'v'
+
+  workflow_dispatch:
+    # The custom 'Version' input field allows running the workflow for older git
+    # refs, where this workflow file did not exist yet. This would not be
+    # possible with the builtin "Use workflow from" input field.
+    inputs:
+      version:
+        description: "Version"
+        default: "master"
+        required: true
+
+env:
+  JAVA_VERSION: '17'
+  JAVA_DISTRO: 'temurin'
+  PLUGIN_VERSION: '2.9.1'
+  SBOM_TYPE: 'makeAggregateBom'
+  PROJECT_VERSION: "${{ github.event_name == 'release' && github.event.release.tag_name || github.event.inputs.version }}"
+
+permissions:
+  contents: read
+
+jobs:
+  generate-sbom:
+    runs-on: ubuntu-latest
+    outputs:
+      # Make env var available in re-usuable workflow (see actions/runner#2372)
+      project-version: ${{ env.PROJECT_VERSION }}
+    steps:
+      - name: Checkout repository at '${{ env.PROJECT_VERSION }}'
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
+          ref: ${{ env.PROJECT_VERSION }}
+          persist-credentials: false
+
+      - name: Setup Java SDK
+        uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRO }}
+
+      - name: Generate
+        run: |
+          mvn org.cyclonedx:cyclonedx-maven-plugin:${PLUGIN_VERSION}:${SBOM_TYPE} \
+              -DoutputFormat=json \
+              -DoutputDirectory=target \
+              -DoutputName=cyclonedx
+
+
+      - name: Upload
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: sbom
+          path: target/cyclonedx.json
+
+  # Store SBOM and metadata in a predefined format for otterdog to pick up
+  store-sbom-data:
+    needs: ['generate-sbom']
+    uses: eclipse-csi/workflows/.github/workflows/store-sbom-data.yml@main
+    with:
+      projectName: 'JGit'
+      projectVersion: ${{ needs.generate-sbom.outputs.project-version }}
+      bomArtifact: 'sbom'
+      bomFilename: 'cyclonedx.json'
+      parentProject: '6638fa7e-8518-4528-9419-e24f629b7e9f'
+

--- a/pom.xml
+++ b/pom.xml
@@ -609,7 +609,7 @@
         <artifactId>cyclonedx-maven-plugin</artifactId>
         <configuration>
           <projectType>library</projectType>
-          <schemaVersion>1.4</schemaVersion>
+          <schemaVersion>1.6</schemaVersion>
           <includeBomSerialNumber>true</includeBomSerialNumber>
           <includeCompileScope>true</includeCompileScope>
           <includeProvidedScope>true</includeProvidedScope>


### PR DESCRIPTION
This PR aims to bootstrap the EF Security Team initiative of generating and publishing SBOMs for project releases, with the goal of enhancing software supply chain security.

To not interfere with your existing release processes, this PR proposes a new workflow to generate and publish SBOMs autonomously, following release tag pushes for the **JGit** product. The workflow respects the existing SBOM plugin configuration in `pom.xml`, which is updated to use the latest SBOM schema version.[^1]

In addition to the release event, the workflow can be triggered manually to test SBOM generation, or to generate SBOMs for past releases.

Following a workflow run, the EF self-service system automatically publishes the SBOM on our DependencyTrack [instance](https://sbom.eclipse.org/), under the **Eclipse JGit → JGit** entry. To view the uploaded results, you can log into DependencyTrack by using your EF account credentials.

If the PR is merged, we kindly ask you to run the workflow once, so that we can confirm a successful SBOM upload from your repository. You can find instructions to [trigger a workflow manually in the GitHub documentation](https://docs.github.com/en/actions/how-tos/manage-workflow-runs/manually-run-a-workflow#running-a-workflow):

- The name of the workflow is "Generate Maven SBOM”
- Enter an existing release tag in the “Version” input field of the “Run workflow” UI, e.g. “3.0.0”

Also note that edits by maintainers are enabled for this PR, so feel free to update the workflow as you see fit, and do let us know if you have any questions!

More details about our SBOM Early Adopters initiative at EF can be found in our [Security Handbook](https://eclipse-csi.github.io/security-handbook/sbom/index.html).

[^1]: We recommend removing the SBOM configuration from `pom.xml`, and defining necessary (non-default) options only in the new workflow to avoid surprising behaviour. Removing the configuration in `pom.xml` also fixes a bug, which currently generates an aggregate SBOM for each module.