### PR TITLE
Add toString() to FetchResult and RebaseResult

### DIFF
--- a/org.eclipse.jgit.test/tst/org/eclipse/jgit/api/RebaseResultTest.java
+++ b/org.eclipse.jgit.test/tst/org/eclipse/jgit/api/RebaseResultTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2026, hanweiwei and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Distribution License v. 1.0 which is available at
+ * https://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+package org.eclipse.jgit.api;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.junit.Test;
+
+public class RebaseResultTest {
+
+	@Test
+	public void toStringOk() {
+		String s = RebaseResult.OK_RESULT.toString();
+		assertNotNull(s);
+		assertTrue(s.contains("status=OK"));
+		assertTrue(s.startsWith("RebaseResult["));
+		assertTrue(s.endsWith("]"));
+	}
+
+	@Test
+	public void toStringUpToDate() {
+		String s = RebaseResult.UP_TO_DATE_RESULT.toString();
+		assertTrue(s.contains("status=UP_TO_DATE"));
+	}
+
+	@Test
+	public void toStringFastForward() {
+		String s = RebaseResult.FAST_FORWARD_RESULT.toString();
+		assertTrue(s.contains("status=FAST_FORWARD"));
+	}
+
+	@Test
+	public void toStringConflicts() {
+		RebaseResult result = RebaseResult.conflicts(
+				List.of("file1.txt", "file2.txt"));
+		String s = result.toString();
+		assertTrue(s.contains("status=CONFLICTS"));
+		assertTrue(s.contains("file1.txt"));
+		assertTrue(s.contains("file2.txt"));
+	}
+
+	@Test
+	public void toStringUncommittedChanges() {
+		RebaseResult result = RebaseResult.uncommittedChanges(
+				List.of("dirty.java"));
+		String s = result.toString();
+		assertTrue(s.contains("status=UNCOMMITTED_CHANGES"));
+		assertTrue(s.contains("dirty.java"));
+	}
+
+	@Test
+	public void toStringAborted() {
+		String s = RebaseResult.ABORTED_RESULT.toString();
+		assertTrue(s.contains("status=ABORTED"));
+	}
+}

--- a/org.eclipse.jgit.test/tst/org/eclipse/jgit/transport/FetchResultTest.java
+++ b/org.eclipse.jgit.test/tst/org/eclipse/jgit/transport/FetchResultTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2026, hanweiwei and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Distribution License v. 1.0 which is available at
+ * https://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+package org.eclipse.jgit.transport;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class FetchResultTest {
+
+	@Test
+	public void toStringEmpty() {
+		FetchResult result = new FetchResult();
+		String s = result.toString();
+		assertNotNull(s);
+		assertTrue(s.startsWith("FetchResult["));
+		assertTrue(s.contains("0 ref update(s)"));
+		assertTrue(s.endsWith("]"));
+	}
+
+	@Test
+	public void toStringWithUri() throws Exception {
+		FetchResult result = new FetchResult();
+		result.setAdvertisedRefs(new URIish("https://example.com/repo.git"),
+				java.util.Collections.emptyMap());
+		String s = result.toString();
+		assertTrue(s.contains("example.com"));
+	}
+
+	@Test
+	public void toStringWithSubmodule() {
+		FetchResult result = new FetchResult();
+		result.addSubmodule("sub/path", new FetchResult());
+		String s = result.toString();
+		assertTrue(s.contains("1 submodule(s)"));
+	}
+}

--- a/org.eclipse.jgit.test/tst/org/eclipse/jgit/transport/FetchResultTest.java
+++ b/org.eclipse.jgit.test/tst/org/eclipse/jgit/transport/FetchResultTest.java
@@ -12,6 +12,8 @@ package org.eclipse.jgit.transport;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import java.util.Collections;
+
 import org.junit.Test;
 
 public class FetchResultTest {
@@ -30,7 +32,7 @@ public class FetchResultTest {
 	public void toStringWithUri() throws Exception {
 		FetchResult result = new FetchResult();
 		result.setAdvertisedRefs(new URIish("https://example.com/repo.git"),
-				java.util.Collections.emptyMap());
+				Collections.emptyMap());
 		String s = result.toString();
 		assertTrue(s.contains("example.com"));
 	}

--- a/org.eclipse.jgit/src/org/eclipse/jgit/api/RebaseResult.java
+++ b/org.eclipse.jgit/src/org/eclipse/jgit/api/RebaseResult.java
@@ -303,4 +303,25 @@ public class RebaseResult {
 		return uncommittedChanges;
 	}
 
+	@SuppressWarnings("nls")
+	@Override
+	public String toString() {
+		StringBuilder sb = new StringBuilder();
+		sb.append("RebaseResult[status=").append(status);
+		if (currentCommit != null) {
+			sb.append(", currentCommit=")
+					.append(currentCommit.abbreviate(7).name());
+		}
+		if (conflicts != null && !conflicts.isEmpty()) {
+			sb.append(", conflicts=").append(conflicts);
+		}
+		if (failingPaths != null && !failingPaths.isEmpty()) {
+			sb.append(", failingPaths=").append(failingPaths.keySet());
+		}
+		if (uncommittedChanges != null && !uncommittedChanges.isEmpty()) {
+			sb.append(", uncommittedChanges=").append(uncommittedChanges);
+		}
+		sb.append("]");
+		return sb.toString();
+	}
 }

--- a/org.eclipse.jgit/src/org/eclipse/jgit/transport/FetchResult.java
+++ b/org.eclipse.jgit/src/org/eclipse/jgit/transport/FetchResult.java
@@ -63,4 +63,28 @@ public class FetchResult extends OperationResult {
 	public Map<String, FetchResult> submoduleResults() {
 		return Collections.unmodifiableMap(submodules);
 	}
+
+	@SuppressWarnings("nls")
+	@Override
+	public String toString() {
+		StringBuilder sb = new StringBuilder();
+		sb.append("FetchResult[");
+		if (uri != null) {
+			sb.append(uri);
+		}
+		sb.append(": ");
+		sb.append(updates.size()).append(" ref update(s)");
+		if (!forMerge.isEmpty()) {
+			sb.append(", ").append(forMerge.size()).append(" for merge");
+		}
+		if (!submodules.isEmpty()) {
+			sb.append(", ").append(submodules.size()).append(" submodule(s)");
+		}
+		String msgs = getMessages();
+		if (!msgs.isEmpty()) {
+			sb.append(", messages: ").append(msgs.trim());
+		}
+		sb.append("]");
+		return sb.toString();
+	}
 }


### PR DESCRIPTION
## Summary

`PullResult.toString()` delegates to `FetchResult.toString()` and `RebaseResult.toString()`, but neither class overrides `toString()`, resulting in unhelpful output like `org.eclipse.jgit.transport.FetchResult@359d2e00`.

This PR adds meaningful `toString()` implementations to both classes:

**FetchResult**: includes URI, ref update count, submodule count, and remote messages.
```
FetchResult[https://example.com/repo.git: 3 ref update(s), 1 submodule(s)]
```

**RebaseResult**: includes status, current commit, conflicts, failing paths, and uncommitted changes.
```
RebaseResult[status=CONFLICTS, conflicts=[file1.txt, file2.txt]]
```

## Tests
- Added `FetchResultTest` with tests for empty result, result with URI, and result with submodules.
- Added `RebaseResultTest` with tests for OK, UP_TO_DATE, FAST_FORWARD, CONFLICTS, UNCOMMITTED_CHANGES, and ABORTED statuses.

Bug: https://github.com/eclipse-jgit/jgit/issues/256
