### PR TITLE
Fix InvalidPatternException for gitignore bracket patterns containing carriage returns

### DIFF
--- a/org.eclipse.jgit.test/tst/org/eclipse/jgit/ignore/FastIgnoreRuleTest.java
+++ b/org.eclipse.jgit.test/tst/org/eclipse/jgit/ignore/FastIgnoreRuleTest.java
@@ -488,6 +488,31 @@ public class FastIgnoreRuleTest {
 		assertMatched("dir/*a*", "dir/\ra\r");
 	}
 
+	/**
+	 * The macOS community gitignore (https://github.com/github/gitignore) uses
+	 * the pattern {@code Icon[\r]} (with a literal carriage return inside the
+	 * bracket expression) to match the special macOS "Icon\r" file. A bracket
+	 * expression containing a literal CR character must be handled correctly by
+	 * {@code Strings.convertGlob()}: {@code Icon[\r]} must match {@code Icon\r}
+	 * and must NOT match plain {@code Icon}.
+	 *
+	 * <p>Note: when reading from a gitignore file via
+	 * {@link IgnoreNode#parse(java.io.InputStream)}, {@link
+	 * java.io.BufferedReader#readLine()} treats a bare CR as a line terminator,
+	 * which truncates the pattern to {@code Icon[} and causes an {@link
+	 * org.eclipse.jgit.errors.InvalidPatternException} ("Not closed bracket?").
+	 * The fix for that code path is covered by
+	 * {@code IgnoreNodeTest#testBracketExpressionWithCarriageReturnInStream}.
+	 */
+	@Test
+	public void testBracketExpressionWithCarriageReturn() {
+		// "Icon[\r]" with a literal CR inside the brackets should match
+		// a file whose name ends with a CR character.
+		assertMatched("Icon[\r]", "Icon\r");
+		// It must NOT match a file without the trailing CR.
+		assertNotMatched("Icon[\r]", "Icon");
+	}
+
 	private void assertMatched(String pattern, String path) {
 		boolean match = match(pattern, path);
 		String result = path + " is " + (match ? "ignored" : "not ignored")

--- a/org.eclipse.jgit.test/tst/org/eclipse/jgit/ignore/IgnoreNodeTest.java
+++ b/org.eclipse.jgit.test/tst/org/eclipse/jgit/ignore/IgnoreNodeTest.java
@@ -533,6 +533,39 @@ public class IgnoreNodeTest extends RepositoryTestCase {
 		assertEquals(2, node.getRules().size());
 	}
 
+	/**
+	 * Verifies that a bracket expression containing a literal CR character is
+	 * preserved when the gitignore stream is parsed. The macOS community
+	 * gitignore uses the pattern {@code Icon[\r]} (where {@code \r} is ASCII
+	 * 13) to match the special macOS "Icon\r" file. Because
+	 * {@link java.io.BufferedReader#readLine()} treats a bare CR as a line
+	 * terminator, the pattern gets truncated to {@code Icon[}, which causes
+	 * {@code Strings.convertGlob()} to throw
+	 * {@link org.eclipse.jgit.errors.InvalidPatternException} ("Not closed
+	 * bracket?") and produces noisy log warnings for every project that uses
+	 * the macOS global gitignore together with a jgit-based build tool such as
+	 * Gradle.
+	 */
+	@Test
+	public void testBracketExpressionWithCarriageReturnInStream()
+			throws IOException {
+		// Build the raw gitignore bytes: "Icon[" + CR + "]" + LF
+		byte[] gitignoreBytes = "Icon[\r]\n".getBytes(UTF_8);
+		IgnoreNode node = new IgnoreNode();
+		node.parse(new ByteArrayInputStream(gitignoreBytes));
+
+		// The rule must have been loaded without throwing an exception.
+		assertEquals(1, node.getRules().size());
+
+		// The pattern "Icon[\r]" must match a file named "Icon\r".
+		assertEquals(IgnoreNode.MatchResult.IGNORED,
+				node.isIgnored("Icon\r", false));
+
+		// The pattern "Icon[\r]" must NOT match a file named "Icon" (no CR).
+		assertEquals(IgnoreNode.MatchResult.CHECK_PARENT,
+				node.isIgnored("Icon", false));
+	}
+
 	@Test
 	public void testSlashOnlyMatchesDirectory() throws IOException {
 		writeIgnoreFile(".gitignore", "out/");

--- a/org.eclipse.jgit/src/org/eclipse/jgit/ignore/IgnoreNode.java
+++ b/org.eclipse.jgit/src/org/eclipse/jgit/ignore/IgnoreNode.java
@@ -101,10 +101,16 @@ public class IgnoreNode {
 	 * @since 5.11
 	 */
 	public void parse(String sourceName, InputStream in) throws IOException {
+		// Use a custom line reader that treats only '\n' and '\r\n' as line
+		// terminators, matching git's own behaviour. BufferedReader.readLine()
+		// also treats a bare '\r' as a line terminator, which would split a
+		// gitignore pattern like "Icon[\r]" (used by the macOS community
+		// gitignore to match the macOS "Icon\r" file) into two lines "Icon["
+		// and "]", causing an InvalidPatternException ("Not closed bracket?").
 		BufferedReader br = asReader(in);
 		String txt;
 		int lineNumber = 1;
-		while ((txt = br.readLine()) != null) {
+		while ((txt = readLinePreservingCR(br)) != null) {
 			if (txt.length() > 0 && !txt.startsWith("#") && !txt.equals("/")) { //$NON-NLS-1$ //$NON-NLS-2$
 				FastIgnoreRule rule = new FastIgnoreRule();
 				try {
@@ -127,6 +133,53 @@ public class IgnoreNode {
 			}
 			lineNumber++;
 		}
+	}
+
+	/**
+	 * Read the next line from a {@link BufferedReader}, treating only {@code \n}
+	 * and {@code \r\n} as line terminators. Unlike
+	 * {@link BufferedReader#readLine()}, a bare {@code \r} that is not followed
+	 * by {@code \n} is preserved as part of the line content. This matches
+	 * git's own line-reading behaviour for gitignore files.
+	 *
+	 * @param br
+	 *            the reader to read from
+	 * @return the next line (without the line terminator), or {@code null} at
+	 *         end-of-stream
+	 * @throws IOException
+	 *             if an I/O error occurs
+	 */
+	private static String readLinePreservingCR(BufferedReader br)
+			throws IOException {
+		StringBuilder line = null;
+		int ch;
+		while ((ch = br.read()) != -1) {
+			if (line == null) {
+				line = new StringBuilder();
+			}
+			if (ch == '\n') {
+				// LF: end of line (strip the '\n' itself)
+				break;
+			}
+			if (ch == '\r') {
+				// Peek at the next character: if it is '\n', consume it and
+				// end the line (CRLF ending). If it is not '\n', the '\r' is
+				// part of the line content (e.g. inside "Icon[\r]").
+				br.mark(1);
+				int next = br.read();
+				if (next == '\n') {
+					// CRLF: end of line
+					break;
+				}
+				if (next != -1) {
+					br.reset();
+				}
+				line.append((char) ch);
+				continue;
+			}
+			line.append((char) ch);
+		}
+		return line == null ? null : line.toString();
 	}
 
 	private static BufferedReader asReader(InputStream in) {


### PR DESCRIPTION
`IgnoreNode.parse()` uses `BufferedReader.readLine()`, which treats bare CR (`\r`) as a line terminator. The [macOS community gitignore](https://github.com/github/gitignore/blob/main/Global/macOS.gitignore) contains `Icon[\r]` — a literal CR inside brackets, matching the macOS `Icon\r` folder-icon file. `readLine()` splits this into two lines (`Icon[` and `]`), so `Strings.convertGlob()` throws `InvalidPatternException: "Not closed bracket?"` on every build for anyone with that global gitignore.

Fix: replace `readLine()` with a helper that only splits on `\n` and `\r\n`, matching [git's own gitignore parsing behavior](https://git-scm.com/docs/gitignore).

> [!NOTE]
> This was posted by an autonomous AI agent.