### PR TITLE
WorkingTreeIterator: Fix relative core.excludesFile

### DIFF
--- a/org.eclipse.jgit.test/tst/org/eclipse/jgit/api/StatusCommandTest.java
+++ b/org.eclipse.jgit.test/tst/org/eclipse/jgit/api/StatusCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011, Christian Halstrick <christian.halstrick@sap.com> and others
+ * Copyright (C) 2011, 2026 Christian Halstrick <christian.halstrick@sap.com> and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0 which is available at
@@ -29,6 +29,26 @@ import org.eclipse.jgit.util.FS;
 import org.junit.Test;
 
 public class StatusCommandTest extends RepositoryTestCase {
+
+	@Test
+	public void testRelativeCoreExcludesFile() throws Exception {
+		try (Git git = new Git(db)) {
+			writeTrashFile("sub/myexclusions", "ignoring\n");
+			FileBasedConfig config = db.getConfig();
+			config.setString("core", null, "excludesFile", "sub/myexclusions");
+			config.save();
+			writeTrashFile("foo", "foo");
+			writeTrashFile("ignoring", "foo");
+			writeTrashFile("sub/foo", "foo");
+			writeTrashFile("sub/ignoring", "foo");
+
+			Status stat = git.status().call();
+			assertEquals(Sets.of("foo", "sub/foo", "sub/myexclusions"),
+					stat.getUntracked());
+			assertEquals(Sets.of("ignoring", "sub/ignoring"),
+					stat.getIgnoredNotInIndex());
+		}
+	}
 
 	@Test
 	public void testEmptyStatus() throws NoWorkTreeException,

--- a/org.eclipse.jgit.test/tst/org/eclipse/jgit/ignore/IgnoreNodeTest.java
+++ b/org.eclipse.jgit.test/tst/org/eclipse/jgit/ignore/IgnoreNodeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010, Red Hat Inc. and others
+ * Copyright (C) 2010, 2026 Red Hat Inc. and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0 which is available at
@@ -56,6 +56,32 @@ public class IgnoreNodeTest extends RepositoryTestCase {
 		if (walk != null) {
 			walk.close();
 		}
+	}
+
+	@Test
+	public void testRelativeCoreExcludesFileResolvedAgainstWorkTree()
+			throws Exception {
+		// C Git resolves a relative core.excludesFile against the work tree
+		// root, not the process current directory. See
+		// https://github.com/eclipse-jgit/jgit/issues/280
+		writeIgnoreFile("sub/myexclusions", "ignoring");
+		db.getConfig().setString("core", null, "excludesFile",
+				"sub/myexclusions");
+		db.getConfig().save();
+
+		writeTrashFile("foo", "foo");
+		writeTrashFile("ignoring", "foo");
+		writeTrashFile("sub/foo", "foo");
+		writeTrashFile("sub/ignoring", "foo");
+
+		beginWalk();
+		assertEntry(F, tracked, "foo");
+		assertEntry(F, ignored, "ignoring");
+		assertEntry(D, tracked, "sub");
+		assertEntry(F, tracked, "sub/foo");
+		assertEntry(F, ignored, "sub/ignoring");
+		assertEntry(F, tracked, "sub/myexclusions");
+		endWalk();
 	}
 
 	@Test

--- a/org.eclipse.jgit/src/org/eclipse/jgit/treewalk/WorkingTreeIterator.java
+++ b/org.eclipse.jgit/src/org/eclipse/jgit/treewalk/WorkingTreeIterator.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2008, Shawn O. Pearce <spearce@spearce.org>
  * Copyright (C) 2010, Christian Halstrick <christian.halstrick@sap.com>
  * Copyright (C) 2010, Matthias Sohn <matthias.sohn@sap.com>
- * Copyright (C) 2012, 2022, Robin Rosenberg and others
+ * Copyright (C) 2012, 2026, Robin Rosenberg and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0 which is available at
@@ -1291,9 +1291,12 @@ public abstract class WorkingTreeIterator extends AbstractTreeIterator {
 		IgnoreNode load(IgnoreNode parent) throws IOException {
 			IgnoreNode coreExclude = new IgnoreNodeWithParent(parent);
 			FS fs = repository.getFS();
+			// C Git resolves a relative core.excludesFile against the work
+			// tree root (it chdirs there). Do not use the process CWD.
 			Path path = repository.getConfig().getPath(
 					ConfigConstants.CONFIG_CORE_SECTION, null,
-					ConfigConstants.CONFIG_KEY_EXCLUDESFILE, fs, null, null);
+					ConfigConstants.CONFIG_KEY_EXCLUDESFILE, fs,
+					repository.getWorkTree(), null);
 			if (path != null) {
 				if (Files.exists(path)) {
 					loadRulesFromFile(coreExclude, path.toFile());


### PR DESCRIPTION
Thank you for contributing to JGit!

JGit uses [GerritHub](https://eclipse.gerrithub.io) for code changes and review, therefore **pull requests in this repository cannot be merged**.

Please make sure you have read the section on [contributing patches](https://github.com/eclipse-egit/egit/wiki/Contributor-Guide#contributing-patches) of the [Contributor Guide](https://github.com/eclipse-egit/egit/wiki/Contributor-Guide).

## Summary

- Fixes https://github.com/eclipse-jgit/jgit/issues/280
- C Git resolves a relative `core.excludesFile` against the work tree root. JGit passed `null` to `Config.getPath`, which uses the process current directory, so `jgit status` missed the file when run from a subdirectory.
- `WorkingTreeIterator.RootIgnoreNode` now resolves the path against `repository.getWorkTree()`. `~/` expansion is unchanged.

## Test plan

- [x] `IgnoreNodeTest#testRelativeCoreExcludesFileResolvedAgainstWorkTree`
- [x] `StatusCommandTest#testRelativeCoreExcludesFile` (issue #280 layout: `sub/myexclusions` + `ignoring` files)
- [x] Full `IgnoreNodeTest` + `StatusCommandTest` (43 tests) on JDK 17:

```
JAVA_HOME=<jdk17> mvn -pl org.eclipse.jgit.test -am test \
  -Dtest=IgnoreNodeTest,StatusCommandTest \
  -Dsurefire.failIfNoSpecifiedTests=false
```

Result: Tests run: 43, Failures: 0, Errors: 0

Gerrit Change-Id: `I7cf1a7d768068b475388a81d274f92ef85743618`

I could not push to GerritHub from this environment (no GerritHub SSH/HTTP credentials). Happy to push the same commit to `refs/for/master` once access is available.